### PR TITLE
Support for fixing the update mechanism for kubernetes deployed Nuvlaedges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -278,7 +278,7 @@ COPY --link conf/example/* /etc/nuvlaedge/
 # ------------------------------------------------------------------------
 # Set up Job engine
 # ------------------------------------------------------------------------
-RUN apk add --no-cache gettext docker-cli docker-cli-compose
+RUN apk add --no-cache gettext docker-cli docker-cli-compose helm
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community kubectl
 
 COPY --link --from=job-lite /app/* /app/


### PR DESCRIPTION
We add helm to the nuvlaedge container definition.
So that the nuvlaedge container can be used for a kubernetes Job to run helm