### PR TITLE
Refactor and bugfixes

### DIFF
--- a/nuvlaedge/agent/__init__.py
+++ b/nuvlaedge/agent/__init__.py
@@ -35,81 +35,20 @@ def update_periods(nuvlaedge_resource: dict):
     root_logger.info(f'Heartbeat period: {heartbeat_interval}s')
 
 
-def update_nuvlaedge_configuration(
-        current_nuvlaedge_res: dict,
-        old_nuvlaedge_res: dict,
-        infra: Infrastructure):
-    """
-    Checks new the new nuvlaedge resource configuration for differences on the local
-    registered one and updates (if required) the vpn and/or the heartbeat and telemetry
-    periodic reports
-    Args:
-        current_nuvlaedge_res:
-        old_nuvlaedge_res:
-        infra:
-    """
-    if old_nuvlaedge_res['updated'] != current_nuvlaedge_res['updated']:
-        update_periods(current_nuvlaedge_res)
-
-        vpn_server_id = current_nuvlaedge_res.get("vpn-server-id")
-        if vpn_server_id != old_nuvlaedge_res.get("vpn-server-id"):
-            root_logger.info(f'VPN Server ID has been added/changed in Nuvla: '
-                             f'{vpn_server_id}')
-            infra.commission_vpn()
-
-
-def resource_synchronization(
-        activator: Activate,
-        exit_event: Event,
-        infra: Infrastructure) -> dict:
-    """
-    Checks if the NuvlaEdge resource has been updated in Nuvla
-
-    Args:
-        activator:
-        exit_event:
-        infra:
-
-    Returns:
-
-    """
-
-    nuvlaedge_resource: dict = activator.get_nuvlaedge_info()
-
-    if nuvlaedge_resource.get('state', '').startswith('DECOMMISSION'):
-        root_logger.info(f"Remote NuvlaEdge resource state "
-                         f"{nuvlaedge_resource.get('state', '')}, exiting agent")
-        exit_event.set()
-        return {}
-
-    vpn_server_id = nuvlaedge_resource.get("vpn-server-id")
-    old_nuvlaedge_resource = activator.create_nb_document_file(nuvlaedge_resource)
-
-    update_nuvlaedge_configuration(nuvlaedge_resource,
-                                   old_nuvlaedge_resource,
-                                   infra)
-
-    # if there's a mention to the VPN server, then watch the VPN credential
-    if vpn_server_id:
-        infra.watch_vpn_credential(vpn_server_id)
-
-    return {}
-
-
 def initialize_action(name: str,
                       period: int,
                       action: callable,
                       remaining_time: float = 0,
-                      arguments: tuple | None = None,
-                      karguments: dict | None = None):
+                      args: tuple | None = None,
+                      kwargs: dict | None = None):
     action_handler.add(
         TimedAction(
             name=name,
             period=period,
             action=action,
             remaining_time=remaining_time,
-            arguments=arguments,
-            karguments=karguments))
+            args=args,
+            kwargs=kwargs))
 
 
 def main():
@@ -126,26 +65,22 @@ def main():
     socket.setdefaulttimeout(CTE.NETWORK_TIMEOUT)
 
     main_event: Event = Event()
-
-    main_agent: Agent = Agent()
+    main_agent: Agent = Agent(exit_event=main_event,
+                              on_nuvlaedge_update=update_periods)
     main_agent.initialize_agent()
 
     # Adds the main agent actions to the agent handler
     initialize_action(name='heartbeat',
                       period=CTE.HEARTBEAT_INTERVAL,
-                      remaining_time=CTE.HEARTBEAT_INTERVAL,
                       action=main_agent.send_heartbeat,
-                      arguments=(update_periods,))
+                      remaining_time=CTE.HEARTBEAT_INTERVAL)
     initialize_action(name='telemetry',
                       period=CTE.REFRESH_INTERVAL,
                       action=main_agent.send_telemetry,
                       remaining_time=CTE.REFRESH_INTERVAL/2)
     initialize_action(name='sync_resources',
                       period=86400,
-                      action=resource_synchronization,
-                      arguments=(main_agent.activate,
-                                 main_event,
-                                 main_agent.infrastructure))
+                      action=main_agent.sync_nuvlaedge_resource)
 
     update_periods(main_agent.nuvlaedge_resource.data)
 

--- a/nuvlaedge/agent/activate.py
+++ b/nuvlaedge/agent/activate.py
@@ -55,8 +55,7 @@ class Activate(NuvlaEdgeCommon):
             # But maybe the API was provided via env?
             api_key, api_secret = self.get_api_keys()
             if api_key and api_secret:
-                self.activate_logger.info(f'Found API key set in environment, with key'
-                                          f' value {api_key}')
+                self.activate_logger.info(f'Found API key set in environment, with key value {api_key}')
                 self.user_info = {
                     "api-key": api_key,
                     "secret-key": api_secret

--- a/nuvlaedge/agent/activate.py
+++ b/nuvlaedge/agent/activate.py
@@ -88,46 +88,42 @@ class Activate(NuvlaEdgeCommon):
 
         return self.user_info
 
-    def create_nb_document_file(self, nuvlaedge_resource: dict) -> dict:
-        """ Writes contextualization file with NB resource content
-
-        :param nuvlaedge_resource: nuvlaedge resource data
-        :return copy of the old NB resource context which is being overwritten
+    def write_ne_document_file(self):
         """
+        Write contextualization file with NE resource content
+        """
+        self.activate_logger.debug(f'Writing nuvlaedge document to file {FILE_NAMES.CONTEXT}')
+        try:
+            self.write_json_to_file(FILE_NAMES.CONTEXT, self.nuvlaedge_resource.data)
+        except Exception as e:
+            self.activate_logger.error(f'Failed to write nuvlaedge document to file {FILE_NAMES.CONTEXT}: {e}')
+            return False
+        return True
 
-        self.activate_logger.info('Managing NB context file {}'.format(FILE_NAMES.CONTEXT))
+    def read_ne_document_file(self) -> dict:
+        """
+        Read contextualization file with NE resource content
 
+        :return the content of the file
+        """
+        self.activate_logger.info(f'NuvlaEdge context file {FILE_NAMES.CONTEXT}')
+
+        current_context = {}
         try:
             current_context = self.read_json_file(FILE_NAMES.CONTEXT)
         except (ValueError, FileNotFoundError):
-            self.activate_logger.warning("Writing {} for the first "
-                                         "time".format(FILE_NAMES.CONTEXT))
-            current_context = {}
-
-        self.write_json_to_file(FILE_NAMES.CONTEXT, nuvlaedge_resource)
+            self.activate_logger.warning(f"Nuvlaedge document file ({FILE_NAMES.CONTEXT}) doesn't exist or is invalid")
+        except Exception as e:
+            self.activate_logger.error(f'Failed to read nuvlaedge document file ({FILE_NAMES.CONTEXT}): {e}')
 
         return current_context
 
-    def get_nuvlaedge(self) -> CimiResource:
-        """ Retrieves the respective resource from Nuvla """
+    def fetch_nuvlaedge(self) -> CimiResource:
+        """ Retrieve the NuvlaEdge resource from Nuvla """
         self.nuvlaedge_resource = self.api().get(self.nuvlaedge_id)
         return self.nuvlaedge_resource
 
-    def get_nuvlaedge_info(self) -> dict:
-        return self.get_nuvlaedge().data
-
-    def update_nuvlaedge_resource(self) -> tuple:
-        """ Updates the static information about the NuvlaEdge
-
-        :return: current and old NuvlaEdge resources
-        """
-
+    def nuvla_login(self):
         self.authenticate(self.api(),
                           self.user_info["api-key"],
                           self.user_info["secret-key"])
-
-        nuvlaedge_resource_data = self.get_nuvlaedge_info()
-
-        old_nuvlaedge_resource_data = self.create_nb_document_file(nuvlaedge_resource_data)
-
-        return nuvlaedge_resource_data, old_nuvlaedge_resource_data

--- a/nuvlaedge/agent/agent.py
+++ b/nuvlaedge/agent/agent.py
@@ -48,7 +48,7 @@ class Agent:
         self.logger.debug('Instantiating Agent class')
 
         self.exit_event = exit_event
-        self.on_nuvlaedge_update: Callable[dict] | None = on_nuvlaedge_update
+        self.on_nuvlaedge_update: Callable[[dict], None] | None = on_nuvlaedge_update
 
         # Main NuvlaEdge data
         self.past_status_time: str = ''
@@ -364,7 +364,6 @@ class Agent:
                            self.infrastructure.coe_client.job_engine_lite_image)
 
             if not job.do_nothing:
-
                 try:
                     job.launch()
                 except Exception as ex:

--- a/nuvlaedge/agent/agent.py
+++ b/nuvlaedge/agent/agent.py
@@ -5,7 +5,9 @@ Also controls the execution flow and provides utilities to the children dependen
 
 import logging
 import os
+
 from copy import copy
+from collections.abc import Callable
 from threading import Event, Thread
 
 from nuvla.api.models import CimiResource, CimiResponse
@@ -37,15 +39,23 @@ class Agent:
     agent_event: Event = Event()
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self):
+    def __init__(self,
+                 exit_event: Event | None = None,
+                 on_nuvlaedge_update: Callable[[dict], None] | None = None):
+
         # Class logger
         self.logger: logging.Logger = logging.getLogger(__name__)
         self.logger.debug('Instantiating Agent class')
+
+        self.exit_event = exit_event
+        self.on_nuvlaedge_update: Callable[dict] | None = on_nuvlaedge_update
 
         # Main NuvlaEdge data
         self.past_status_time: str = ''
 
         self.excluded_monitors = os.environ.get('NUVLAEDGE_EXCLUDED_MONITORS', '')
+
+        self.old_nuvlaedge_data = None
 
         self._activate = None
         self._coe_client = None
@@ -118,37 +128,42 @@ class Agent:
         of the NuvlaEdge. If it was activated before, it gathers the previous status.
         If not, it activates the device and again gathers the status
         """
-
         self.logger.info(f'Nuvla endpoint: {self.activate.nuvla_endpoint}')
-        self.logger.info(
-            f'Nuvla connection insecure: {str(self.activate.nuvla_endpoint_insecure)}')
+        if self.activate.nuvla_endpoint_insecure:
+            self.logger.info(f'Nuvla connection insecure: {self.activate.nuvla_endpoint_insecure}')
 
         while True:
             can_activate, user_info = self.activate.activation_is_possible()
             if can_activate or user_info:
                 break
             else:
-                self.logger.info(
-                    f'Activation not yet possible {can_activate}-{user_info}')
+                self.logger.info(f'Activation not yet possible: can_activate={can_activate} user_info={user_info}')
 
-            self.agent_event.wait(timeout=3)
+            self.agent_event.wait(timeout=5)
 
         if not user_info:
             self.logger.info('NuvlaEdge not yet activated, proceeding')
             self.activate.activate()
 
-        # Gather resources post-activation
-        nuvlaedge_resource_data, _ = self.activate.update_nuvlaedge_resource()
-        self.logger.info(f'NuvlaEdge status id {self.nuvlaedge_status_id}')
+        # Login to Nuvla
+        self.activate.nuvla_login()
 
-    def get_nuvlaedge(self) -> CimiResource:
-        return self.activate.get_nuvlaedge()
+        # Gather nuvlaedge resource post-activation
+        self.fetch_nuvlaedge_resource()
+        self.logger.info(f'NuvlaEdge status id: {self.nuvlaedge_status_id}')
+
+    def fetch_nuvlaedge_resource(self) -> CimiResource:
+        return self.activate.fetch_nuvlaedge()
 
     @property
     def nuvlaedge_resource(self) -> CimiResource:
         if not self.activate.nuvlaedge_resource:
-            self.get_nuvlaedge()
+            self.fetch_nuvlaedge_resource()
         return self.activate.nuvlaedge_resource
+
+    @property
+    def nuvlaedge_data(self) -> dict:
+        return self.nuvlaedge_resource.data
 
     @property
     def nuvlaedge_operations(self) -> dict:
@@ -156,7 +171,7 @@ class Agent:
 
     @property
     def nuvlaedge_status_id(self) -> str:
-        return self.nuvlaedge_resource.data.get(CTE.NUVLAEDGE_STATUS_RES_NAME)
+        return self.nuvlaedge_data.get(CTE.NUVLAEDGE_STATUS_RES_NAME)
 
     @property
     def nuvlaedge_updated_date(self) -> str:
@@ -199,12 +214,59 @@ class Agent:
         except Exception as e:
             self.logger.debug(f'Failed to log jobs count: {e}')
 
-    def send_heartbeat(self, update_periods=None) -> dict:
+    def _update_nuvlaedge_configuration(self):
+        """
+        Checks new the new nuvlaedge resource configuration for differences on the local
+        registered one and updates (if required) the vpn and/or the heartbeat and telemetry
+        periodic reports
+        """
+        if not self.old_nuvlaedge_data:
+            self.old_nuvlaedge_data = self.activate.read_ne_document_file()
+
+        old_nuvlaedge_res = self.old_nuvlaedge_data
+        current_nuvlaedge_res = self.nuvlaedge_data
+
+        if old_nuvlaedge_res.get('updated') != current_nuvlaedge_res['updated']:
+            if self.on_nuvlaedge_update:
+                self.on_nuvlaedge_update(self.nuvlaedge_data)
+
+            vpn_server_id = current_nuvlaedge_res.get("vpn-server-id")
+            old_vpn_server_id = old_nuvlaedge_res.get("vpn-server-id")
+            if old_nuvlaedge_res and vpn_server_id != old_vpn_server_id:
+                self.logger.info(f'VPN Server ID has been added/changed in Nuvla '
+                                 f'(from {old_vpn_server_id} to {vpn_server_id}. '
+                                 f'Recommissioning VPN.')
+                self.infrastructure.commission_vpn()
+
+            self.activate.write_ne_document_file()
+            self.old_nuvlaedge_data = current_nuvlaedge_res
+
+    def sync_nuvlaedge_resource(self) -> dict:
+        """
+        Get the NuvlaEdge resource from Nuvla
+        """
+        self.fetch_nuvlaedge_resource()
+
+        # Exit if state is DECOMMISSION(ING)
+        nuvlaedge_state = self.nuvlaedge_data.get('state', '')
+        if nuvlaedge_state.startswith('DECOMMISSION'):
+            self.logger.info(f"Remote NuvlaEdge resource state {nuvlaedge_state}, exiting agent")
+            if self.exit_event:
+                self.exit_event.set()
+            return {}
+
+        self._update_nuvlaedge_configuration()
+
+        # if there's a mention to the VPN server, then watch the VPN credential
+        vpn_server_id = self.nuvlaedge_data.get("vpn-server-id")
+        if vpn_server_id:
+            self.infrastructure.watch_vpn_credential(vpn_server_id)
+
+        return {}
+
+    def send_heartbeat(self) -> dict:
         """
         Send heartbeat
-
-        Args:
-            update_periods: function to call to update periods
 
         Returns: a dict with the response from Nuvla
         """
@@ -212,16 +274,20 @@ class Agent:
             self.logger.info('Heartbeat not supported by Nuvla server. Skipping heartbeat')
             return {}
 
-        response: CimiResponse = self.telemetry.api().operation(
-            self.nuvlaedge_resource, 'heartbeat')
+        response = self.telemetry.api().operation(self.nuvlaedge_resource, 'heartbeat')
 
         self._log_jobs(response, 'heartbeat')
 
         doc_last_updated = response.data.get('doc-last-updated')
-        if doc_last_updated and doc_last_updated != self.nuvlaedge_updated_date:
-            self.get_nuvlaedge()
-            if update_periods:
-                update_periods(self.nuvlaedge_resource.data)
+        nuvlaedge_updated_date = self.nuvlaedge_updated_date
+        old_nuvlaedge_updated_date = self.old_nuvlaedge_data.get('updated') if self.old_nuvlaedge_data else ''
+        if doc_last_updated and (doc_last_updated != nuvlaedge_updated_date
+                                 or doc_last_updated != old_nuvlaedge_updated_date):
+            self.logger.debug(f'send_heartbeat: '
+                              f'doc_last_updated={doc_last_updated} '
+                              f'nuvlaedge_updated_date={nuvlaedge_updated_date} '
+                              f'old_nuvlaedge_updated_date={old_nuvlaedge_updated_date}')
+            self.sync_nuvlaedge_resource()
 
         return response.data
 
@@ -231,6 +297,12 @@ class Agent:
 
         Returns: a dict with the response from Nuvla
         """
+
+        # If heartbeat is not supported by Nuvla server,
+        # the NuvlaEdge resource is fetched on each telemetry request
+        if not self.is_heartbeat_supported_server_side:
+            self.sync_nuvlaedge_resource()
+
         self.logger.debug(f'send_telemetry(, '
                           f'{self.telemetry}, {self.nuvlaedge_status_id},'
                           f' {self.past_status_time})')

--- a/nuvlaedge/agent/common/nuvlaedge_common.py
+++ b/nuvlaedge/agent/common/nuvlaedge_common.py
@@ -29,6 +29,7 @@ class NuvlaEdgeCommon:
 
     ssh_pub_key = os.getenv('NUVLAEDGE_IMMUTABLE_SSH_PUB_KEY')
     vpn_interface_name = os.getenv('VPN_INTERFACE_NAME', 'tun')
+    vpn_client_enable = os.getenv('NUVLAEDGE_VPN_CLIENT_ENABLE')
 
     swarm_manager_token_file = "swarm-manager-token"
     swarm_worker_token_file = "swarm-worker-token"
@@ -417,6 +418,17 @@ class NuvlaEdgeCommon:
         :param operational_status: status of the NuvlaEdge
         """
         util.atomic_write(FILE_NAMES.STATUS_FILE, operational_status)
+
+    @staticmethod
+    def get_vpn_ip():
+        """ Discovers the NuvlaEdge VPN IP  """
+
+        if FILE_NAMES.VPN_IP_FILE.exists() and FILE_NAMES.VPN_IP_FILE.stat().st_size != 0:
+            with FILE_NAMES.VPN_IP_FILE.open('r') as vpn_file:
+                return vpn_file.read().splitlines()[0]
+        else:
+            logging.debug("Cannot infer the NuvlaEdge VPN IP!")
+            return None
 
     @staticmethod
     def write_vpn_conf(values):

--- a/nuvlaedge/agent/infrastructure.py
+++ b/nuvlaedge/agent/infrastructure.py
@@ -101,7 +101,7 @@ class Infrastructure(NuvlaEdgeCommon):
                 client_key = file.read()
 
         except (FileNotFoundError, IndexError):
-            self.logger.warning("Container orchestration API TLS keys have not been set yet!")
+            self.logger.debug("Container orchestration API TLS keys have not been set yet!")
             return []
 
         return client_ca, client_cert, client_key

--- a/nuvlaedge/agent/infrastructure.py
+++ b/nuvlaedge/agent/infrastructure.py
@@ -211,7 +211,7 @@ class Infrastructure(NuvlaEdgeCommon):
     def commission_vpn(self):
         """ (re)Commissions the NB via the agent API
 
-        :return:
+        :return: True on success, False otherwise
         """
         self.logger.info('Starting VPN commissioning...')
 
@@ -659,7 +659,7 @@ class Infrastructure(NuvlaEdgeCommon):
             credential_id = None
 
         if not credential_id:
-            # If you cannot find a VPN credential in Nuvla, then it is either in the
+            # If a VPN credential cannot be found on Nuvla, then it is either in the
             # process of being created or it has been removed from Nuvla
             self.logger.info("VPN server is set but cannot find VPN credential in Nuvla."
                              " Commissioning VPN...")

--- a/nuvlaedge/agent/infrastructure.py
+++ b/nuvlaedge/agent/infrastructure.py
@@ -101,8 +101,7 @@ class Infrastructure(NuvlaEdgeCommon):
                 client_key = file.read()
 
         except (FileNotFoundError, IndexError):
-            self.logger.warning("Container orchestration API TLS keys have not been"
-                                " set yet!")
+            self.logger.warning("Container orchestration API TLS keys have not been set yet!")
             return []
 
         return client_ca, client_cert, client_key
@@ -115,11 +114,10 @@ class Infrastructure(NuvlaEdgeCommon):
         """
 
         if not payload:
-            self.logger.debug("Tried commissioning with empty payload. Nothing "
-                              "to do")
+            self.logger.debug("Tried commissioning with empty payload. Nothing to do")
             return
 
-        self.logger.info("Commissioning the NuvlaEdge...{}".format(payload))
+        self.logger.info(f"Commissioning the NuvlaEdge... ({payload})")
         try:
             self.api()._cimi_post(self.nuvlaedge_id+"/commission", json=payload)
         except Exception as e:
@@ -143,8 +141,7 @@ class Infrastructure(NuvlaEdgeCommon):
                                                       last=1).resources[0].id
                     break
                 except IndexError:
-                    self.logger.exception("Cannot find VPN credential in Nuvla "
-                                          "after commissioning")
+                    self.logger.exception("Cannot find VPN credential in Nuvla after commissioning")
                     time.sleep(2)
                 except Exception as ex:
                     self.logger.info(f"Exception finding VPN credential in Nuvla: {ex}")
@@ -152,8 +149,7 @@ class Infrastructure(NuvlaEdgeCommon):
                 attempts += 1
 
             if not credential_id:
-                self.logger.warning("Failing to provide necessary values for "
-                                          "NuvlaEdge VPN client")
+                self.logger.warning("Failing to provide necessary values for NuvlaEdge VPN client")
                 return None
 
             vpn_credential = self.api()._cimi_get(credential_id)
@@ -260,7 +256,7 @@ class Infrastructure(NuvlaEdgeCommon):
 
         if r.get('returncode', -1) != 0:
             self.logger.error(f'Cannot generate certificates for VPN connection: '
-                                    f'{r.get("stdout")} | {r.get("stderr")}')
+                              f'{r.get("stdout")} | {r.get("stderr")}')
             return None, None
 
         try:
@@ -279,8 +275,7 @@ class Infrastructure(NuvlaEdgeCommon):
             with open(self.vpn_key_file) as key:
                 vpn_key = key.read()
         except TimeoutError:
-            self.logger.error(f'Unable to lookup {self.vpn_key_file} and '
-                              f'{self.vpn_csr_file}')
+            self.logger.error(f'Unable to lookup {self.vpn_key_file} and {self.vpn_csr_file}')
             return None, None
 
         return vpn_csr, vpn_key
@@ -624,14 +619,13 @@ class Infrastructure(NuvlaEdgeCommon):
         if vpn_client_running and self.telemetry_instance.get_vpn_ip():
             # just save a copy of the VPN credential locally
             self.write_file(FILE_NAMES.VPN_CREDENTIAL, online_vpn_credential, is_json=True)
-            self.logger.info(f"VPN client is currently running. Saving VPN credential "
-                             f"locally at {FILE_NAMES.VPN_CREDENTIAL}")
+            self.logger.info(f"VPN client is currently running. "
+                             f"Saving VPN credential locally at {FILE_NAMES.VPN_CREDENTIAL}")
         elif vpn_client_exists:
             # there is a VPN credential in Nuvla, but not locally, and the VPN client
             # is not running maybe something went wrong, just recommission
-            self.logger.warning("VPN client is either not running or "
-                                "missing its configuration. Forcing VPN "
-                                "recommissioning...")
+            self.logger.warning("VPN client is either not running or missing its configuration. "
+                                "Forcing VPN recommissioning...")
             self.commission_vpn()
 
     def watch_vpn_credential(self, vpn_is_id=None):
@@ -661,12 +655,11 @@ class Infrastructure(NuvlaEdgeCommon):
         if not credential_id:
             # If a VPN credential cannot be found on Nuvla, then it is either in the
             # process of being created or it has been removed from Nuvla
-            self.logger.info("VPN server is set but cannot find VPN credential in Nuvla."
-                             " Commissioning VPN...")
+            self.logger.info("VPN server is set but cannot find VPN credential in Nuvla. "
+                             "Commissioning VPN...")
 
             if util.file_exists_and_not_empty(FILE_NAMES.VPN_CREDENTIAL):
-                self.logger.warning("NOTE: VPN credential exists locally, so it "
-                                    "was removed from Nuvla")
+                self.logger.warning("NOTE: VPN credential exists locally, so it was removed from Nuvla")
 
             self.commission_vpn()
         else:
@@ -680,8 +673,7 @@ class Infrastructure(NuvlaEdgeCommon):
                 # - IF we don't have it locally, but there's one in Nuvla, then:
                 #     - IF the vpn-client is already running, then all is good, just
                 #     save the VPN credential locally
-                self.logger.warning("VPN credential exists in Nuvla, but not "
-                                    "locally")
+                self.logger.warning("VPN credential exists in Nuvla, but not locally")
                 self.fix_vpn_credential_mismatch(vpn_credential_nuvla)
 
     def set_immutable_ssh_key(self):
@@ -699,7 +691,7 @@ class Infrastructure(NuvlaEdgeCommon):
                 original_ssh_key = sshf.read()
                 if self.ssh_pub_key != original_ssh_key:
                     self.logger.warning(f'Received new SSH key but the original '
-                                              f'{original_ssh_key} is immutable.Ignoring')
+                                        f'{original_ssh_key} is immutable.Ignoring')
             return
 
         event = {
@@ -730,8 +722,7 @@ class Infrastructure(NuvlaEdgeCommon):
                 else [self.nuvlaedge_id]
             event['acl'] = {'owners': event_owners}
 
-            self.logger.info(f'Setting immutable SSH key {self.ssh_pub_key} for '
-                             f'{self.installation_home}')
+            self.logger.info(f'Setting immutable SSH key {self.ssh_pub_key} for {self.installation_home}')
             try:
                 with util.timeout(10):
                     if not self.coe_client.install_ssh_key(self.ssh_pub_key,
@@ -753,7 +744,6 @@ class Infrastructure(NuvlaEdgeCommon):
         while True:
             try:
                 self.try_commission()
-            except RuntimeError as ex:
-                self.logger.exception('Error while trying to commission NuvlaEdge',
-                                      ex)
+            except RuntimeError:
+                self.logger.exception('Error while trying to commission NuvlaEdge')
             time.sleep(self.refresh_period)

--- a/nuvlaedge/agent/monitor/__init__.py
+++ b/nuvlaedge/agent/monitor/__init__.py
@@ -78,7 +78,7 @@ class Monitor(ABC, Thread):
         """
         ...
 
-    def run_update_data(self, raise_on_exception=False, monitor_name=None):
+    def run_update_data(self, monitor_name=None):
         if not monitor_name:
             monitor_name = self.name
 
@@ -88,8 +88,6 @@ class Monitor(ABC, Thread):
             self.updated = True
         except Exception as e:
             self.logger.exception(f'Something went wrong updating monitor {monitor_name}: {e}', e)
-            if raise_on_exception:
-                raise
         finally:
             self.last_process_duration = time.perf_counter() - init_time
 

--- a/nuvlaedge/agent/monitor/__init__.py
+++ b/nuvlaedge/agent/monitor/__init__.py
@@ -19,7 +19,7 @@ class Monitor(ABC, Thread):
     along the device.
     """
     def __init__(self, name: str, data_type: Type, enable_monitor: bool,
-                 thread_period: int = 10):
+                 thread_period: int = 60):
         super().__init__()
         # Define default thread attributes
         self.daemon = True

--- a/nuvlaedge/agent/monitor/__init__.py
+++ b/nuvlaedge/agent/monitor/__init__.py
@@ -87,7 +87,7 @@ class Monitor(ABC, Thread):
             self.update_data()
             self.updated = True
         except Exception as e:
-            self.logger.exception(f'Something went wrong updating monitor {monitor_name}: {e}', e)
+            self.logger.exception(f'Something went wrong updating monitor {monitor_name}: {e}')
         finally:
             self.last_process_duration = time.perf_counter() - init_time
 

--- a/nuvlaedge/agent/monitor/components/geolocation.py
+++ b/nuvlaedge/agent/monitor/components/geolocation.py
@@ -98,7 +98,7 @@ class GeoLocationMonitor(Monitor):
 
     def update_data(self):
         if not self.is_thread:
-            if time.time() - self.last_update < self.thread_period:
+            if (time.time() - self.last_update) < self.thread_period:
                 return
 
         for service, info in self._LOCATION_SERVICES.items():

--- a/nuvlaedge/agent/monitor/components/geolocation.py
+++ b/nuvlaedge/agent/monitor/components/geolocation.py
@@ -54,8 +54,7 @@ class GeoLocationMonitor(Monitor):
             self.logger.debug(f"Inferring geolocation with 3rd party service {service}")
             return requests.get(service, allow_redirects=False, timeout=5).json()
         except requests.RequestException as e:
-            self.logger.error(f"Could not infer IP-based geolocation from "
-                              f"service {service}: {e}")
+            self.logger.error(f"Could not infer IP-based geolocation from service {service}: {e}")
             return None
 
     def parse_geolocation(self, service_name: str, service_info: dict,

--- a/nuvlaedge/agent/monitor/components/gpio.py
+++ b/nuvlaedge/agent/monitor/components/gpio.py
@@ -95,8 +95,8 @@ class GpioMonitor(Monitor):
         except KeyError:
             # if there's any other issue while doing so, it means the provided argument
             # is not valid
-            self.logger.error(f"Invalid list of indexes {indexes} for GPIO pin "
-                              f"in {line}. Cannot parse this pin")
+            self.logger.error(f"Invalid list of indexes {indexes} for GPIO pin in {line}. "
+                              f"Cannot parse this pin")
             return None
 
     def parse_pin_line(self, pin_line: str) -> \
@@ -127,9 +127,7 @@ class GpioMonitor(Monitor):
             self.logger.error(f"Subprocess class error: {ex}")
 
         except FileNotFoundError as ex:
-            self.logger.error(
-                f"No command {ex} found, GPIO monitor shouldn't be active if the command"
-                f" is not present")
+            self.logger.error(f"No command {ex} found, GPIO monitor shouldn't be active if the command is not present")
         return []
 
     def update_data(self):

--- a/nuvlaedge/agent/monitor/components/network.py
+++ b/nuvlaedge/agent/monitor/components/network.py
@@ -363,7 +363,7 @@ class NetworkMonitor(Monitor):
         # 2.- Default Local Gateway
         # 3.- Public
         # 4.- Swarm
-        self.logger.info('Updating data in Network monitor')
+        self.logger.debug('Updating data in Network monitor')
         if not nuvla_report.get('resources'):
             nuvla_report['resources'] = {}
 

--- a/nuvlaedge/agent/monitor/components/network.py
+++ b/nuvlaedge/agent/monitor/components/network.py
@@ -52,8 +52,7 @@ class NetworkMonitor(Monitor):
         self._ip_route_image: str = self.coe_client.current_image
 
         self.engine_project_name: str = self.get_engine_project_name()
-        self.logger.info(f'Running network monitor for project '
-                         f'{self.engine_project_name}')
+        self.logger.info(f'Running network monitor for project {self.engine_project_name}')
         self.iproute_container_name: str = f'{self.engine_project_name}-iproute'
 
         self.last_public_ip: float = 0.0
@@ -82,7 +81,7 @@ class NetworkMonitor(Monitor):
 
         except requests.Timeout as ex:
             reason: str = f'Connection to server timed out: {ex}'
-            self.logger.error(f'Cannot retrieve public IP. {reason}')
+            self.logger.error(f'Cannot retrieve public IP: {reason}')
         except Exception as e:
             self.logger.error(f'Cannot retrieve public IP: {e}')
 
@@ -173,8 +172,7 @@ class NetworkMonitor(Monitor):
                 with open(f"{stats}/tx_bytes", encoding='UTF-8') as tx_file:
                     tx_bytes = int(tx_file.read())
             except (FileNotFoundError, NotADirectoryError):
-                self.logger.warning(
-                    f"Cannot calculate net usage for interface {interface}")
+                self.logger.warning(f"Cannot calculate net usage for interface {interface}")
                 continue
 
             # we compute the net stats since the beginning of the NB lifetime
@@ -185,8 +183,8 @@ class NetworkMonitor(Monitor):
                         self.first_net_stats[interface].get('bytes-transmitted', 0):
 
                     # then the system counters were reset
-                    self.logger.warning(f'Host network counters seem to have '
-                                        f'been reset for network interface {interface}')
+                    self.logger.warning(f'Host network counters seem to have been reset for network interface '
+                                        f'{interface}')
 
                     if interface in previous_net_stats:
                         # in this case, because the numbers no longer correlate,

--- a/nuvlaedge/agent/monitor/components/network.py
+++ b/nuvlaedge/agent/monitor/components/network.py
@@ -38,6 +38,7 @@ class NetworkMonitor(Monitor):
 
         super().__init__(self.__class__.__name__, NetworkingData,
                          enable_monitor=enable_monitor)
+        self.telemetry = telemetry
         # list of network interfaces
         self.updaters: list = [self.set_public_data,
                                self.set_local_data,
@@ -312,18 +313,9 @@ class NetworkMonitor(Monitor):
     def set_vpn_data(self) -> None:
         """ Discovers the NuvlaEdge VPN IP  """
 
-        # Check if file exists and not empty
-        if FILE_NAMES.VPN_IP_FILE.exists() and \
-                FILE_NAMES.VPN_IP_FILE.stat().st_size != 0:
-            with FILE_NAMES.VPN_IP_FILE.open() as file:
-                it_line = file.read()
-                ip_address: str = str(it_line.splitlines()[0])
-
-            if self.data.ips.vpn != ip_address:
-                self.data.ips.vpn = ip_address
-
-        else:
-            self.logger.warning("Cannot infer the NuvlaEdge VPN IP!")
+        vpn_ip = self.telemetry.get_vpn_ip()
+        if vpn_ip and self.data.ips.vpn != vpn_ip:
+            self.data.ips.vpn = vpn_ip
 
     def set_swarm_data(self) -> None:
         """ Discovers the host SWARM IP address """

--- a/nuvlaedge/agent/monitor/components/temperature.py
+++ b/nuvlaedge/agent/monitor/components/temperature.py
@@ -93,16 +93,15 @@ class TemperatureMonitor(Monitor):
             zone_name, temp_value = self.read_temperature_file(zone_path, temp_path)
 
             if not zone_name or not temp_value:
-                self.logger.warning(f'Thermal zone {zone_path} or temperature '
-                                    f'{temp_path} value is missing')
+                self.logger.warning(f'Thermal zone {zone_path} or temperature {temp_path} value is missing')
                 continue
 
             try:
                 self.update_temperature_entry(zone_name, float(temp_value)/1000)
 
             except (ValueError, TypeError) as ex:
-                self.logger.warning(f'Cannot convert temperature {temp_value} at '
-                                    f'{temp_path}. Reason: {str(ex)}')
+                self.logger.warning(f'Cannot convert temperature {temp_value} at {temp_path}. '
+                                    f'Reason: {str(ex)}')
 
     def update_data(self):
         if not self.data.temperatures:

--- a/nuvlaedge/agent/monitor/components/vulnerabilities.py
+++ b/nuvlaedge/agent/monitor/components/vulnerabilities.py
@@ -33,8 +33,7 @@ class VulnerabilitiesMonitor(Monitor):
                     try:
                         return json.loads(file_content)
                     except json.decoder.JSONDecodeError as ex:
-                        self.logger.error(f'Vulnerabilities content:[ {file_content} ] '
-                                          f'not properly formatted - {ex}')
+                        self.logger.error(f'Vulnerabilities content: [ {file_content} ] not properly formatted - {ex}')
                         return None
 
         return None

--- a/nuvlaedge/agent/orchestrator/__init__.py
+++ b/nuvlaedge/agent/orchestrator/__init__.py
@@ -141,7 +141,7 @@ class COEClient(ABC):
         """
 
     @abstractmethod
-    def read_system_issues(self, node_info):
+    def read_system_issues(self, node_info) -> (list, list):
         """
         Checks if the underlying container management system is reporting any errors or
          warnings

--- a/nuvlaedge/agent/orchestrator/docker.py
+++ b/nuvlaedge/agent/orchestrator/docker.py
@@ -264,7 +264,7 @@ class DockerClient(COEClient):
             compute_api = self._get_component_container(util.compute_api_service_name)
             local_net = list(compute_api.attrs['NetworkSettings']['Networks'].keys())[0]
         except Exception as e:
-            logger.info(f'Cannot infer compute-api network for local job {job_id}: {e}')
+            logger.debug(f'Cannot infer compute-api network for local job {job_id}: {e}')
 
         # Get environment variables and volumes from job-engine-lite container
         volumes = {

--- a/nuvlaedge/agent/orchestrator/docker.py
+++ b/nuvlaedge/agent/orchestrator/docker.py
@@ -63,8 +63,7 @@ class DockerClient(COEClient):
         except docker.errors.APIError as e:
             if self.lost_quorum_hint in str(e):
                 # quorum is lost
-                logger.warning('Quorum is lost. This node will no longer support '
-                               'Service and Cluster management')
+                logger.warning('Quorum is lost. This node will no longer support Service and Cluster management')
 
         return ()
 
@@ -106,8 +105,7 @@ class DockerClient(COEClient):
         try:
             return container.ports['5000/tcp'][0]['HostPort']
         except (KeyError, IndexError) as ex:
-            logger.warning(f'Cannot infer ComputeAPI external port, container attributes '
-                           f'not properly formatted: {ex}')
+            logger.warning(f'Cannot infer ComputeAPI external port, container attributes not properly formatted: {ex}')
         return ''
 
     def get_api_ip_port(self):
@@ -222,8 +220,8 @@ class DockerClient(COEClient):
         if containers_count < 1:
             raise docker.errors.NotFound(f'Container with the following labels not found: {labels}')
         elif containers_count > 1:
-            logger.warning(f'More than one component container found for '
-                           f'service name "{service_name}" and project name "{project_name}": {containers}')
+            logger.warning(f'More than one component container found for service name "{service_name}" '
+                           f'and project name "{project_name}": {containers}')
         return containers[0]
 
     def _get_component_container(self, service_name, container_name=None):
@@ -356,7 +354,7 @@ class DockerClient(COEClient):
                 cpu_percent = (cpu_delta / system_delta) * online_cpus * 100.0
         except (IndexError, KeyError, ValueError, ZeroDivisionError) as e:
             logger.warning('Failed to get CPU usage for container '
-                            f'{cs.get("id","?")[:12]} ({cs.get("name")}): {e}')
+                           f'{cs.get("id","?")[:12]} ({cs.get("name")}): {e}')
 
         return cpu_percent
 
@@ -383,7 +381,7 @@ class DockerClient(COEClient):
         except (IndexError, KeyError, ValueError, ZeroDivisionError) as e:
             mem_percent = mem_usage = mem_limit = 0.00
             logger.warning('Failed to get Memory consumption for container '
-                            f'{cstats.get("id","?")[:12]} ({cstats.get("name")}): {e}')
+                           f'{cstats.get("id","?")[:12]} ({cstats.get("name")}): {e}')
 
         return mem_percent, mem_usage, mem_limit
 
@@ -404,7 +402,7 @@ class DockerClient(COEClient):
                               for iface in cstats["networks"]) / 1000 / 1000
         except (IndexError, KeyError, ValueError) as e:
             logger.warning('Failed to get Network consumption for container '
-                            f'{cstats.get("id","?")[:12]} ({cstats.get("name")}): {e}')
+                           f'{cstats.get("id","?")[:12]} ({cstats.get("name")}): {e}')
 
         return net_in, net_out
 
@@ -424,12 +422,12 @@ class DockerClient(COEClient):
                 blk_in = float(io_bytes_recursive[0]["value"] / 1000 / 1000)
             except (IndexError, KeyError, TypeError) as e:
                 logger.warning('Failed to get block usage (In) for container '
-                                f'{cstats.get("id","?")[:12]} ({cstats.get("name")}): {e}')
+                               f'{cstats.get("id","?")[:12]} ({cstats.get("name")}): {e}')
             try:
                 blk_out = float(io_bytes_recursive[1]["value"] / 1000 / 1000)
             except (IndexError, KeyError, TypeError) as e:
                 logger.warning('Failed to get block usage (Out) for container '
-                                f'{cstats.get("id","?")[:12]} ({cstats.get("name")}): {e}')
+                               f'{cstats.get("id","?")[:12]} ({cstats.get("name")}): {e}')
 
         return blk_out, blk_in
 
@@ -463,7 +461,7 @@ class DockerClient(COEClient):
                 containers_stats.append((container, container.stats(stream=False)))
             except Exception as e:
                 logger.warning('Failed to get stats for container '
-                                f'{container.short_id} ({container.name}): {e}')
+                               f'{container.short_id} ({container.name}): {e}')
         return containers_stats
 
     def collect_container_metrics(self):
@@ -734,8 +732,7 @@ class DockerClient(COEClient):
             result = run(cmd, stdout=PIPE, stderr=PIPE, timeout=5,
                          encoding='UTF-8', shell=True).stdout
         except TimeoutExpired as e:
-            logger.warning(f'Could not infer if Kubernetes is also installed '
-                                f'on the host: {str(e)}')
+            logger.warning(f'Could not infer if Kubernetes is also installed on the host: {str(e)}')
             return k8s_cluster_info
 
         if not result:

--- a/nuvlaedge/agent/orchestrator/kubernetes.py
+++ b/nuvlaedge/agent/orchestrator/kubernetes.py
@@ -664,8 +664,7 @@ class KubernetesClient(COEClient):
             self.client.delete_namespaced_pod(name, namespace)
             self._wait_pod_deleted(namespace, name)
         except ApiException as ex:
-            log.warning('Failed removing pod %s in %s: %s', name, namespace,
-                        ex.reason)
+            log.warning('Failed removing pod %s in %s: %s', name, namespace, ex.reason)
         except TimeoutException as ex_timeout:
             log.warning('Timeout waiting for pod to be deleted: %s', ex_timeout)
 

--- a/nuvlaedge/agent/telemetry.py
+++ b/nuvlaedge/agent/telemetry.py
@@ -129,8 +129,7 @@ class Telemetry(NuvlaEdgeCommon):
         self.edge_status: EdgeStatus = EdgeStatus()
 
         self.excluded_monitors: List[str] = excluded_monitors.replace("'", "").split(',')
-        self.logger.info(f'Excluded monitors received in Telemetry'
-                         f' {self.excluded_monitors}')
+        self.logger.info(f'Excluded monitors received in Telemetry: {self.excluded_monitors}')
         self.monitor_list: Dict[str, Monitor] = {}
         self.initialize_monitors()
 
@@ -194,8 +193,7 @@ class Telemetry(NuvlaEdgeCommon):
                             f' {self.mqtt_broker_host}')
             return
         except socket.gaierror:
-            logging.warning("The NuvlaEdge MQTT broker is not reachable...trying again"
-                            " later")
+            logging.warning("The NuvlaEdge MQTT broker is not reachable...trying again later")
             self.mqtt_telemetry.disconnect()
             return
 
@@ -299,11 +297,9 @@ class Telemetry(NuvlaEdgeCommon):
                 if it_monitor.updated:
                     it_monitor.populate_nb_report(status_dict)
                 else:
-                    self.logger.info(f'Data not updated yet in monitor '
-                                     f'{it_monitor.name}')
-            except Exception as ex:
-                self.logger.exception(f'Error retrieving data from monitor '
-                                      f'{it_monitor.name}.', ex)
+                    self.logger.info(f'Data not updated yet in monitor {it_monitor.name}')
+            except Exception:
+                self.logger.exception(f'Error retrieving data from monitor {it_monitor.name}.')
 
     def get_status(self):
         """ Gets several types of information to populate the NuvlaEdge status """

--- a/nuvlaedge/agent/telemetry.py
+++ b/nuvlaedge/agent/telemetry.py
@@ -268,7 +268,6 @@ class Telemetry(NuvlaEdgeCommon):
             status_dict: dictionary containing the report for Nuvla to be updated by
             each monitor
         """
-        monitor_process_time: Dict = {}
 
         for monitor_name, it_monitor in self.monitor_list.items():
             self.logger.debug(f'Monitor: {it_monitor.name} - '
@@ -288,19 +287,11 @@ class Telemetry(NuvlaEdgeCommon):
                     self.monitor_list[monitor_name] = monitor
 
             else:
-                init_time: float = time.time()
+                it_monitor.run_update_data(monitor_name=monitor_name)
 
-                try:
-                    it_monitor.update_data()
-                    it_monitor.updated = True
-                except Exception as ex:
-                    self.logger.exception(f'Something went wrong updating monitor '
-                                          f'{monitor_name}. Error: {ex}', ex)
-
-                monitor_process_time[it_monitor.name] = time.time() - init_time
-
-        self.logger.debug(f'Monitors processing time '
-                          f'{json.dumps(monitor_process_time, indent=4)}')
+        monitor_process_duration = {k: v.last_process_duration for k, v in self.monitor_list.items()}
+        self.logger.debug(f'Monitors processing duration: '
+                          f'{json.dumps(monitor_process_duration, indent=4)}')
 
         # Retrieve monitoring data
         for it_monitor in self.monitor_list.values():

--- a/nuvlaedge/agent/telemetry.py
+++ b/nuvlaedge/agent/telemetry.py
@@ -270,25 +270,22 @@ class Telemetry(NuvlaEdgeCommon):
         """
         monitor_process_time: Dict = {}
 
-        def create_new_monitor_thread(name, telemetry: Telemetry, **kwargs):
-            th = get_monitor(name)(name, telemetry, True, **kwargs)
-            th.start()
-            return th
-
         for monitor_name, it_monitor in self.monitor_list.items():
-            self.logger.debug(f' --- Monitor: {it_monitor.name} -- '
-                                f'Threaded: {it_monitor.is_thread} -- '
-                                f'Alive: {it_monitor.is_alive()}-')
+            self.logger.debug(f'Monitor: {it_monitor.name} - '
+                              f'Threaded: {it_monitor.is_thread} - '
+                              f'Alive: {it_monitor.is_alive()}')
 
-            if is_thread_creation_needed(
-                    monitor_name,
-                    it_monitor,
-                    log_not_alive=(logging.INFO, 'Recreating {} thread.'),
-                    log_alive=(logging.DEBUG, 'Thread {} is alive'),
-                    log_not_exist=(logging.INFO, 'Creating {} thread.')):
+            if it_monitor.is_thread:
+                if is_thread_creation_needed(
+                        monitor_name,
+                        it_monitor,
+                        log_not_alive=(logging.INFO, 'Recreating {} thread.'),
+                        log_alive=(logging.DEBUG, 'Thread {} is alive'),
+                        log_not_exist=(logging.INFO, 'Creating {} thread.')):
 
-                self.monitor_list[monitor_name] = create_new_monitor_thread(monitor_name,
-                                                                            self)
+                    monitor = get_monitor(monitor_name)(monitor_name, self, True)
+                    monitor.start()
+                    self.monitor_list[monitor_name] = monitor
 
             else:
                 init_time: float = time.time()

--- a/nuvlaedge/agent/telemetry.py
+++ b/nuvlaedge/agent/telemetry.py
@@ -371,13 +371,3 @@ class Telemetry(NuvlaEdgeCommon):
                           json.dumps(all_status), encoding='UTF-8')
 
         self.status.update(new_status)
-
-    def get_vpn_ip(self):
-        """ Discovers the NuvlaEdge VPN IP  """
-
-        if FILE_NAMES.VPN_IP_FILE.exists() and FILE_NAMES.VPN_IP_FILE.stat().st_size != 0:
-            with FILE_NAMES.VPN_IP_FILE.open('r') as vpn_file:
-                return vpn_file.read().splitlines()[0]
-        else:
-            logging.warning("Cannot infer the NuvlaEdge VPN IP!")
-            return None

--- a/nuvlaedge/agent/telemetry.py
+++ b/nuvlaedge/agent/telemetry.py
@@ -138,10 +138,10 @@ class Telemetry(NuvlaEdgeCommon):
         """
         Auxiliary function to extract some control from the class initialization
         It gathers the available monitors and initializes them saving the reference into
-        the monitor_list attribute of Telemtry
+        the monitor_list attribute of Telemetry
         """
         for mon in active_monitors:
-            if mon.split('_')[0] in self.excluded_monitors:
+            if mon.rsplit('_', 1)[0] in self.excluded_monitors:
                 continue
             self.monitor_list[mon] = (get_monitor(mon)(mon, self, True))
 

--- a/nuvlaedge/common/timed_actions.py
+++ b/nuvlaedge/common/timed_actions.py
@@ -12,8 +12,8 @@ class TimedAction:
     action: callable
     period: int
     remaining_time: float = 0  # Allow configurability for delayed starts
-    karguments: dict[str, any] = field(default_factory=dict)
-    arguments: tuple[any] | None = None
+    args: tuple[any] | None = None
+    kwargs: dict[str, any] = field(default_factory=dict)
     uuid: str = uuid.uuid4()
 
     def __call__(self):
@@ -22,13 +22,13 @@ class TimedAction:
                          f'{self.remaining_time}s')
             return
 
-        if not self.arguments:
-            self.arguments = tuple()
+        if not self.args:
+            self.args = tuple()
 
-        if not self.karguments:
-            self.karguments = {}
+        if not self.kwargs:
+            self.kwargs = {}
 
-        ret = self.action(*self.arguments, **self.karguments)
+        ret = self.action(*self.args, **self.kwargs)
 
         self.remaining_time = self.period
         return ret

--- a/nuvlaedge/on_stop/__init__.py
+++ b/nuvlaedge/on_stop/__init__.py
@@ -74,7 +74,7 @@ def cleanup_networks(network_driver):
             try:
                 network.remove()
             except Exception as e:
-                logging.debug(f'Exception {e} retrying removal of network {network.name}')
+                logging.debug(f'Exception retrying removal of network {network.name}: {e}')
                 logging.error(f'Cannot remove {network.name}')
 
 
@@ -105,7 +105,7 @@ def cleanup_datagateway(is_cluster_manager):
             try:
                 remove_container_or_service(dg_svc)
             except Exception as e:
-                logging.debug(f'Exception {e} retrying removal of component {dg_svc.name}')
+                logging.debug(f'Exception retrying removal of component {dg_svc.name}: {e}')
                 logging.error(f'Cannot remove {dg_svc.name}')
 
 

--- a/nuvlaedge/peripherals/bluetooth/__init__.py
+++ b/nuvlaedge/peripherals/bluetooth/__init__.py
@@ -79,17 +79,19 @@ def compare_bluetooth(bluetooth, ble):
     output = []
 
     for device in bluetooth:
-        if device[0] not in ble:
-            d = {
-                "identifier": device[0],
-                "class": device[2],
-                "interface": "Bluetooth"
-            }
+        device_id = device[0]
+        # if device_id not in ble:
+        d = {
+            "identifier": device_id,
+            "class": device[2],
+            "interface": "Bluetooth"
+        }
+        if device[1] != "":
+            d["name"] = device[1]
+        output.append(d)
 
-            if device[1] != "":
-                d["name"] = device[1]
-
-            output.append(d)
+        # elif device[1] and not ble[device_id].get('name'):
+        #     ble[device_id]['name'] = device[1]
 
     return output
 
@@ -294,20 +296,27 @@ def cod_converter(cod_decimal_string):
 
 
 async def bluetooth_manager():
-    try:
-        # list
-        bluetooth_devices = device_discovery()
-        logger.info(bluetooth_devices)
-    except Exception as e:
-        bluetooth_devices = []
-        logger.exception(f"Failed to discover BT devices: {e}")
 
+    bluetooth_devices = []
+    try:
+        bluetooth_devices = device_discovery()
+        logger.debug(f'Bluetooth devices: {bluetooth_devices}')
+    except Exception as e:
+        logger.error(f"Failed to discover BT devices: {e}")
+        logger.debug("Exception", exc_info=e)
+
+    ble_devices = {}
     try:
         ble_devices = await ble_device_discovery()
+        logger.debug(f'BLE devices: {ble_devices}')
     except Exception as e:
-        ble_devices = {}
-        logger.exception(f"Failed to discover BLE devices: {e}")
-    logger.info(f'BLE Devices {ble_devices}')
+        logger.error(f"Failed to discover BLE devices: {e}")
+        logger.debug("Exception", exc_info=e)
+
+    if bluetooth_devices or ble_devices:
+        logger.info(f'Found {len(bluetooth_devices)} Bluetooth devices and {len(ble_devices)} BLE devices')
+    else:
+        logger.info('No device found')
 
     bluetooth = compare_bluetooth(bluetooth_devices, ble_devices)
     output = ble_devices

--- a/nuvlaedge/peripherals/bluetooth/__init__.py
+++ b/nuvlaedge/peripherals/bluetooth/__init__.py
@@ -1,17 +1,21 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """NuvlaEdge Peripheral Manager Bluetooth
+
 This service provides bluetooth device discovery.
+
 """
 
-import bluetooth as bt
 import logging
+
+from typing import List
+
+import bluetooth as bt
+
 from bleak import BleakScanner, BLEDevice, AdvertisementData, BleakClient
 from bleak.backends._manufacturers import MANUFACTURERS
-from typing import List
 from bleak.uuids import uuidstr_to_str
-import asyncio
-import sys
 
 from nuvlaedge.peripherals.peripheral import Peripheral
 from nuvlaedge.common.nuvlaedge_config import parse_arguments_and_initialize_logging
@@ -334,19 +338,19 @@ async def bluetooth_manager():
     return output
 
 
-async def main():
+def main():
     parse_arguments_and_initialize_logging('Bluetooth Peripheral')
 
     logger.info('Starting bluetooth manager')
 
     bluetooth_peripheral: Peripheral = Peripheral(name='bluetooth', async_mode=True)
 
-    await bluetooth_peripheral.run(bluetooth_manager)
+    bluetooth_peripheral.run(bluetooth_manager)
 
 
 def entry():
-    asyncio.run(main())
+    main()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/nuvlaedge/peripherals/bluetooth/__main__.py
+++ b/nuvlaedge/peripherals/bluetooth/__main__.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from nuvlaedge.peripherals.bluetooth import main
-import asyncio
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/nuvlaedge/peripherals/gpu/__init__.py
+++ b/nuvlaedge/peripherals/gpu/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # -*- coding: utf-8 -*-
 
 """NuvlaEdge Peripheral GPU Manager
@@ -16,7 +15,6 @@ import os
 import csv
 import json
 import re
-import asyncio
 
 from shutil import which
 
@@ -403,19 +401,19 @@ def gpu_check(api_url):
     return False
 
 
-async def main():
+def main():
     global logger
     parse_arguments_and_initialize_logging('GPU Peripheral')
 
     logger = logging.getLogger(__name__)
     gpu_peripheral: Peripheral = Peripheral('gpu')
 
-    await gpu_peripheral.run(flow, runtime=RUNTIME_PATH, host_files_path=HOST_FILES)
+    gpu_peripheral.run(flow, runtime=RUNTIME_PATH, host_files_path=HOST_FILES)
 
 
 def entry():
-    asyncio.run(main())
+    main()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/nuvlaedge/peripherals/gpu/__main__.py
+++ b/nuvlaedge/peripherals/gpu/__main__.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from nuvlaedge.peripherals.gpu import main
-import asyncio
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/nuvlaedge/peripherals/modbus/__init__.py
+++ b/nuvlaedge/peripherals/modbus/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # -*- coding: utf-8 -*-
 
 """NuvlaEdge Peripheral Manager Modbus
@@ -14,15 +13,12 @@ It provides:
  - modbus2mqtt on demand
 """
 
+import fileinput
+import logging
+import os
 import socket
 import struct
-import os
-import logging
-import fileinput
 import sys
-import asyncio
-import ipaddress
-import subprocess
 
 from nuvlaedge.peripherals.peripheral import Peripheral
 from nuvlaedge.common.nuvlaedge_config import parse_arguments_and_initialize_logging
@@ -146,7 +142,7 @@ def determine_ip_addresses(list_of_ip_addresses):
 
     return list_of_ip_addresses
 
-async def main():
+def main():
     global logger
 
     parse_arguments_and_initialize_logging('Modbus Peripheral')
@@ -163,12 +159,12 @@ async def main():
 
     list_of_ip_addresses = determine_ip_addresses(gateway_ip)
 
-    await modbus_peripheral.run(manage_modbus_peripherals, ip_address=list_of_ip_addresses)
+    modbus_peripheral.run(manage_modbus_peripherals, ip_address=list_of_ip_addresses)
 
 
 def entry():
-    asyncio.run(main())
+    main()
 
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    main()

--- a/nuvlaedge/peripherals/modbus/__main__.py
+++ b/nuvlaedge/peripherals/modbus/__main__.py
@@ -1,6 +1,7 @@
-from nuvlaedge.peripherals.modbus import main
-import asyncio
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
+from nuvlaedge.peripherals.modbus import main
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    main()

--- a/nuvlaedge/peripherals/network/__init__.py
+++ b/nuvlaedge/peripherals/network/__init__.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-
 # -*- coding: utf-8 -*-
 
 """NuvlaEdge Peripheral Manager Network
+
 This service provides network devices discovery.
+
 """
 
-import logging
-import requests
-import os
-import xmltodict
-import re
 import base64
-import asyncio
+import logging
+import os
+import re
+import requests
+import xmltodict
 
 from nuvlaedge.peripherals.peripheral import Peripheral
 from nuvlaedge.common.nuvlaedge_config import parse_arguments_and_initialize_logging
@@ -24,7 +24,6 @@ from urllib.parse import urlparse
 from wsdiscovery.discovery import ThreadedWSDiscovery as WSDiscovery
 from zeroconf import ZeroconfServiceTypes, ServiceBrowser, Zeroconf
 
-scanning_interval = 30
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -311,7 +310,7 @@ def network_manager(**kwargs):
     return output
 
 
-async def main():
+def main():
     global logger
     parse_arguments_and_initialize_logging('Network Peripheral')
 
@@ -329,8 +328,12 @@ async def main():
 
     ws_daemon = WSDiscovery()
 
-    await network_peripheral.run(network_manager, zc_obj=zeroconf, zc_listener=zeroconf_listener, wsdaemon=ws_daemon)
+    network_peripheral.run(network_manager, zc_obj=zeroconf, zc_listener=zeroconf_listener, wsdaemon=ws_daemon)
 
 
 def entry():
-    asyncio.run(main())
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/nuvlaedge/peripherals/network/__init__.py
+++ b/nuvlaedge/peripherals/network/__init__.py
@@ -254,11 +254,11 @@ def format_zeroconf_services(services):
                     # for additional classes
                     if 'class' in dict_properties:
                         output[identifier]['class'].append(dict_properties['class'])
-            except Exception as ex:
+            except Exception:
                 # this is only to get additional info on the peripheral, if it fails, we can live without it
                 logger.debug('Failed gathering extra information from peripheral', exc_info=True)
 
-        except Exception as ex:
+        except Exception:
             logger.exception(f'Unable to categorize Zeroconf peripheral {service_name} with data: {service_data}')
             continue
 

--- a/nuvlaedge/peripherals/network/__init__.py
+++ b/nuvlaedge/peripherals/network/__init__.py
@@ -113,8 +113,8 @@ def ssdp_manager():
             if 'x-friendly-name' in device:
                 try:
                     alt_name = base64.b64decode(device.get('x-friendly-name')).decode()
-                except Exception as ex:
-                    logger.debug('Exception decoding name', ex)
+                except Exception:
+                    logger.debug('Exception decoding name', exc_info=True)
 
             name = device_from_location.get('friendlyName', alt_name)
             description = device_from_location.get('modelDescription',
@@ -256,10 +256,10 @@ def format_zeroconf_services(services):
                         output[identifier]['class'].append(dict_properties['class'])
             except Exception as ex:
                 # this is only to get additional info on the peripheral, if it fails, we can live without it
-                logger.debug('Failed gathering extra information from peripheral', ex)
+                logger.debug('Failed gathering extra information from peripheral', exc_info=True)
 
         except Exception as ex:
-            logger.exception(f'Unable to categorize Zeroconf peripheral {service_name} with data: {service_data}', ex)
+            logger.exception(f'Unable to categorize Zeroconf peripheral {service_name} with data: {service_data}')
             continue
 
     return output

--- a/nuvlaedge/peripherals/network/__main__.py
+++ b/nuvlaedge/peripherals/network/__main__.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from nuvlaedge.peripherals.network import main
-import asyncio
 
 if __name__ == '__main__':
-    asyncio.run(main())
+    main()

--- a/nuvlaedge/peripherals/peripheral.py
+++ b/nuvlaedge/peripherals/peripheral.py
@@ -1,8 +1,7 @@
-"""
-
-"""
+import asyncio
 import json
 import logging
+
 from threading import Event
 
 from nuvlaedge.broker import NuvlaEdgeBroker
@@ -27,10 +26,10 @@ class Peripheral:
     def hash_discoveries(devices: dict) -> int:
         return hash(json.dumps(devices, sort_keys=True))
 
-    async def run_single_iteration(self, run_peripheral: callable, **kwargs):
+    def run_single_iteration(self, run_peripheral: callable, **kwargs):
         self.logger.info('Discovering peripherals')
         if self._async_mode:
-            discovered_peripherals: dict = await run_peripheral(**kwargs)
+            discovered_peripherals: dict = asyncio.run(run_peripheral(**kwargs))
         else:
             discovered_peripherals: dict = run_peripheral(**kwargs)
         # Maybe we should always publish, regardless of the previous device and let the manager decide what to
@@ -42,12 +41,12 @@ class Peripheral:
                                 discovered_peripherals,
                                 self._name)
 
-    async def run(self, run_peripheral: callable, **kwargs):
+    def run(self, run_peripheral: callable, **kwargs):
         """
         Runs the peripheral telemetry function
         :return:
         """
         e = Event()
         while True:
-            await self.run_single_iteration(run_peripheral, **kwargs)
+            self.run_single_iteration(run_peripheral, **kwargs)
             e.wait(timeout=self._scanning_interval)

--- a/nuvlaedge/peripherals/peripheral_manager.py
+++ b/nuvlaedge/peripherals/peripheral_manager.py
@@ -47,11 +47,11 @@ class PeripheralManager(Thread):
         Checks which peripheral scanners are currently running
         :return:
         """
-        self.logger.info(f'Getting peripheral status from: {FILE_NAMES.PERIPHERALS_FOLDER}')
+        self.logger.debug(f'Getting peripheral status from: {FILE_NAMES.PERIPHERALS_FOLDER}')
 
         for f in FILE_NAMES.PERIPHERALS_FOLDER.iterdir():
             if f.is_dir():
-                self.logger.info(f'{f} peripheral manager running')
+                self.logger.debug(f'{f} peripheral manager running')
                 self.running_peripherals.add(f)
 
     def process_new_peripherals(self, new_peripherals: dict[str, PeripheralData]):

--- a/nuvlaedge/peripherals/peripheral_manager_db.py
+++ b/nuvlaedge/peripherals/peripheral_manager_db.py
@@ -248,7 +248,7 @@ class PeripheralsDBManager:
                 update_flag = True
                 self.remove_peripheral(p)
 
-        self.logger.info('After removing in the local DB, backup to file')
+        self.logger.debug('After removing in the local DB, backup to file')
         if update_flag:
             self.update_local_storage()
 
@@ -262,5 +262,5 @@ class PeripheralsDBManager:
         for identifier, data in new_peripherals.items():
             self._latest_update[identifier] = datetime.now()
 
-        self.logger.info('After editing the local DB, backup to file')
+        self.logger.debug('After editing the local DB, backup to file')
         self.update_local_storage()

--- a/nuvlaedge/peripherals/peripheral_manager_db.py
+++ b/nuvlaedge/peripherals/peripheral_manager_db.py
@@ -172,7 +172,7 @@ class PeripheralsDBManager:
         del_status = self.remove_remote_peripheral(self.content.get(peripheral_id).id)
 
         if del_status in [200, 201]:
-            self.logger.info(f'Peripheral {peripheral_id} successfully removed from Nuvla, removing from local')
+            self.logger.info(f'Peripheral "{peripheral_id}" successfully removed from Nuvla, removing from local')
             self.remove_local_peripheral(peripheral_id)
         else:
             self.logger.warning(f'Error {del_status} deleting peripheral from Nuvla')
@@ -244,7 +244,7 @@ class PeripheralsDBManager:
 
             # Updated field should always be filled, either when updating from Nuvla or when creating the Peripheral
             if self.peripheral_expired(p):
-                self.logger.info(f'Peripheral last report more than {self.EXPIRATION_TIME/60} min ago, removing')
+                self.logger.info(f'Peripheral "{p}" last report more than {self.EXPIRATION_TIME/60} min ago, removing')
                 update_flag = True
                 self.remove_peripheral(p)
 

--- a/nuvlaedge/security/security.py
+++ b/nuvlaedge/security/security.py
@@ -256,8 +256,7 @@ class Security:
         self.api.logout()
 
         if not nuvla_vul_db:
-            logger.warning(f'Nuvla endpoint {self.nuvla_endpoint} does not '
-                                f'contain any vulnerability')
+            logger.warning(f'Nuvla endpoint {self.nuvla_endpoint} does not contain any vulnerability')
             return
 
         temp_db_last_update = nuvla_vul_db[0].data.get('updated')
@@ -300,8 +299,7 @@ class Security:
         try:
             return attributes[0]
         except IndexError:
-            logger.error(f'Failed to extract vulnerability ID from'
-                         f' {attributes}')
+            logger.error(f'Failed to extract vulnerability ID from {attributes}')
             return None
 
     @staticmethod

--- a/nuvlaedge/system_manager/common/coe_client.py
+++ b/nuvlaedge/system_manager/common/coe_client.py
@@ -429,7 +429,7 @@ class Docker(COEClient):
 
         if docker_major_version < self.minimum_version:
             self.logging.error("Your Docker version is too old: {}. MIN REQUIREMENTS: Docker {} or newer"
-                           .format(docker_major_version, self.minimum_version))
+                               .format(docker_major_version, self.minimum_version))
             return False
 
         return True

--- a/nuvlaedge/system_manager/supervise.py
+++ b/nuvlaedge/system_manager/supervise.py
@@ -178,8 +178,8 @@ class Supervise(Containers):
             try:
                 if '409' in str(e):
                     # already exists
-                    self.log.warning(f'Despite the request to launch the Data Gateway, '
-                                     f'{name} seems to exist already. Forcing its restart just in case')
+                    self.log.warning(f'Despite the request to launch the Data Gateway, {name} seems to exist already. '
+                                     f'Forcing its restart just in case')
                     if self.is_cluster_enabled and self.i_am_manager:
                         self.coe_client.client.services.get(name).force_update()
                     else:
@@ -592,8 +592,7 @@ class Supervise(Containers):
                         self.log.warning(f'Network {target_network.name} ceased to exist '
                                          f'during connectivity check. Nothing to do.')
                         return
-                    self.log.error(f'Unable to reconnect {container.name} to '
-                                   f'network {target_network.name}: {str(e)}')
+                    self.log.error(f'Unable to reconnect {container.name} to network {target_network.name}: {str(e)}')
                     self.operational_status.append((utils.status_degraded,
                                                     'NuvlaEdge containers lost their network connection'))
 
@@ -611,8 +610,8 @@ class Supervise(Containers):
 
         try:
             project_name = self.get_project_name()
-        except Exception as ex:
-            self.log.debug('Errors getting project name', ex)
+        except Exception:
+            self.log.debug('Errors getting project name', exc_info=True)
             return
 
         original_project_label = f'com.docker.compose.project={project_name}'

--- a/tests/agent/monitor/components/test_geolocation.py
+++ b/tests/agent/monitor/components/test_geolocation.py
@@ -105,6 +105,16 @@ class TestGeoLocationMonitor(unittest.TestCase):
             test_geo.update_data()
             self.assertIsNone(test_geo.data.coordinates)
 
+        with patch(self._patch_send_req, autospec=True) as test_send_req, \
+                patch(self._patch_parse_geo, autospec=True) as test_parse:
+            test_parse.return_value = [1, 2]
+            test_send_req.return_value = 'not_none'
+            test_geo.update_data()
+            self.assertEqual(test_geo.data.latitude, 2)
+            self.assertEqual(test_geo.data.longitude, 1)
+        test_geo.data.timestamp = None
+        test_geo.data.coordinates = None
+
         test_geo.is_thread = True
         # Void control
         with patch(self._patch_send_req, autospec=True) as test_send_req:
@@ -141,6 +151,8 @@ class TestGeoLocationMonitor(unittest.TestCase):
         body: dict = {}
         with patch(self._patch_send_req, autospec=True) as test_send_req, \
                 patch(self._patch_parse_geo, autospec=True) as test_parse:
+            test_geo.populate_nb_report(body)
+
             test_parse.return_value = [-1, -1]
             test_send_req.return_value = 'not_none'
 

--- a/tests/agent/monitor/components/test_network.py
+++ b/tests/agent/monitor/components/test_network.py
@@ -194,6 +194,8 @@ class TestNetworkMonitor(unittest.TestCase):
                                        'dev': 'eth0',
                                        'prefsrc': addr1}]
             test_ip_monitor.set_local_data()
+            # TODO: Fix this test which fail from time to time with:
+            # AssertionError: Lists differ: [IP(address='40.40.40.40')] != [IP(address='40.40.40.40'), IP(address='40.40.40.40')]
             self.assertEqual(test_ip_monitor.data.interfaces['eth0'].ips,
                              [IP(address=addr1), IP(address=addr2)])
 

--- a/tests/agent/monitor/components/test_network.py
+++ b/tests/agent/monitor/components/test_network.py
@@ -7,9 +7,9 @@ from typing import List, Dict, Any
 from pathlib import Path
 
 import requests
-from docker import errors as docker_err
 from mock import Mock, mock_open, patch, MagicMock
 
+from nuvlaedge.agent.common.nuvlaedge_common import NuvlaEdgeCommon
 from nuvlaedge.agent.monitor.components import network as monitor
 from nuvlaedge.agent.monitor.data.network_data import NetworkInterface, NetworkingData, IP
 from nuvlaedge.agent.monitor.edge_status import EdgeStatus
@@ -212,9 +212,11 @@ class TestNetworkMonitor(unittest.TestCase):
     def test_set_vpn_data(self, mock_stat, mock_exists):
         vpn_file = Mock()
         status = Mock()
+        mock_telemetry = Mock()
+        mock_telemetry.get_vpn_ip = NuvlaEdgeCommon.get_vpn_ip
         status.iface_data = None
         test_ip_monitor: monitor.NetworkMonitor = \
-            monitor.NetworkMonitor(vpn_file, Mock(), status)
+            monitor.NetworkMonitor(vpn_file, mock_telemetry, status)
 
         it_ip: str = generate_random_ip_address()
         mock_stat.return_value.st_size = 1

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -49,6 +49,10 @@ class TestAgent(TestCase):
         self.test_agent.activate.nuvla_endpoint_insecure = False
         self.test_agent.activate_nuvlaedge()
 
+        self.test_agent._activate = None
+        with patch('nuvlaedge.agent.agent.Activate') as mock_activate:
+            self.test_agent.activate
+
     @patch('nuvlaedge.agent.agent.Infrastructure')
     def test_initialize_infrastructure(self, infra_mock):
         it_mock = Mock()
@@ -298,3 +302,8 @@ class TestAgent(TestCase):
                                                           'vpn-server-id': 'ID'})
         self.test_agent.sync_nuvlaedge_resource()
         mock_infra.watch_vpn_credential.assert_called_with('ID')
+
+        # without exit_event
+        self.test_agent.exit_event = None
+        mock_activator.nuvlaedge_resource = CimiResource({'state': 'DECOMMISSIONING'})
+        self.test_agent.sync_nuvlaedge_resource()

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -10,7 +10,7 @@ from nuvlaedge.agent.activate import Activate
 
 from nuvlaedge.common.timed_actions import TimedAction
 
-from mock import Mock, patch
+from mock import ANY, Mock, PropertyMock, patch
 from unittest import TestCase
 
 
@@ -31,10 +31,14 @@ class TestAgent(TestCase):
     def tearDown(self):
         del os.environ['NUVLAEDGE_UUID']
 
+    def test_fetch_nuvlaedge(self):
+        self.test_agent._activate.nuvlaedge_resource = None
+        self.assertIsNone(self.test_agent.nuvlaedge_resource)
+
     @patch(atomic_write)
     @patch('threading.Event.wait')
     def test_activate_nuvlaedge(self, wait_mock, atomic_write_mock):
-        self.test_agent.activate.activation_is_possible.side_effect = [(False, None), (True, None)]
+        self.test_agent.activate.activation_is_possible.side_effect = [(False, None), (True, None), (True, True)]
 
         self.test_agent.activate.nuvla_login.return_value = \
             ({'nuvlabox-status': 1}, None)
@@ -42,12 +46,18 @@ class TestAgent(TestCase):
         self.assertEqual(self.test_agent.activate.activation_is_possible.call_count, 2)
         self.assertEqual(self.test_agent.activate.nuvla_login.call_count, 1)
 
+        self.test_agent.activate.nuvla_endpoint_insecure = False
+        self.test_agent.activate_nuvlaedge()
+
     @patch('nuvlaedge.agent.agent.Infrastructure')
     def test_initialize_infrastructure(self, infra_mock):
         it_mock = Mock()
         it_mock.installation_home = True
         infra_mock.return_value = it_mock
         with patch(self.agent_open) as mock_open, patch(self.atomic_write), patch(self.os_makedir):
+            self.test_agent.initialize_infrastructure()
+            # Host user home not defined
+            self.test_agent.infrastructure.installation_home = None
             self.test_agent.initialize_infrastructure()
 
     @patch('nuvlaedge.agent.agent.Telemetry')
@@ -83,9 +93,16 @@ class TestAgent(TestCase):
         self.assertEqual(sample_data_return, self.test_agent.send_heartbeat())
         api_mock.operation.assert_called_once_with(nuvlaedge_resource, 'heartbeat')
 
+        with patch('nuvlaedge.agent.agent.Agent.sync_nuvlaedge_resource') as mock_sync:
+            response_mock.data = {'doc-last-updated': 'some date'}
+            self.test_agent.send_heartbeat()
+            mock_sync.assert_called_once()
+
     @patch(os_makedir)
     @patch(atomic_write)
-    def test_send_telemetry(self, atomic_write_mock, os_makedir_mock):
+    @patch('nuvlaedge.agent.agent.Agent.sync_nuvlaedge_resource')
+    @patch('nuvlaedge.agent.agent.Agent.is_heartbeat_supported_server_side', new_callable=PropertyMock)
+    def test_send_telemetry(self, is_heartbeat_mock, sync_mock, atomic_write_mock, os_makedir_mock):
         self.test_agent._telemetry = Mock()
         tel_mock = Mock()
         tel_mock.diff.return_value = ({}, ['a'])
@@ -110,6 +127,24 @@ class TestAgent(TestCase):
         self.test_agent._telemetry.api.side_effect = OSError
         with self.assertRaises(OSError):
             self.test_agent.send_telemetry()
+        self.test_agent._telemetry.api.reset_mock(side_effect=True)
+
+        # heartbeat supported
+        is_heartbeat_mock.return_value = True
+        self.test_agent.send_telemetry()
+        sync_mock.assert_not_called()
+
+        # heartbeat not supported
+        is_heartbeat_mock.return_value = False
+        self.test_agent.send_telemetry()
+        sync_mock.assert_called()
+
+        # status_current_time > past_status_time
+        tel_mock.status.update.reset_mock()
+        tel_mock.status.get.return_value = 2
+        self.test_agent.past_status_time = 1
+        self.test_agent.send_telemetry()
+        api_mock.edit.assert_called_with(ANY, data=ANY, select=['a'])
 
     @patch('nuvlaedge.agent.agent.Job')
     @patch('nuvlaedge.agent.job.Job.launch')
@@ -127,8 +162,13 @@ class TestAgent(TestCase):
         it_mock.do_nothing = False
         it_mock.launch.return_value = "None"
         mock_job.return_value = it_mock
-        self.test_agent.run_pull_jobs(['1'])
+        self.test_agent.run_pull_jobs(['2'])
         self.assertEqual(it_mock.launch.call_count, 1)
+
+        it_mock.launch.side_effect = Exception('error')
+        self.test_agent.run_pull_jobs(['3'])
+        self.assertEqual(it_mock.launch.call_count, 2)
+
 
     @patch('nuvlaedge.agent.agent.Infrastructure')
     @patch('nuvlaedge.agent.agent.Thread.start')
@@ -164,6 +204,23 @@ class TestAgent(TestCase):
         self.test_agent.run_single_cycle(action)
         self.assertEqual(mock_start.call_count, 3)
         pull_mock.assert_called_once()
+
+        # with threads alreay alive
+        with patch('threading.Thread.is_alive') as mock_th_is_alive:
+            mock_th_is_alive.return_value = True
+
+            # telemetry
+            self.test_agent.run_single_cycle(action)
+            self.assertIsNotNone(self.test_agent._peripheral_manager)
+
+            # heartbeat
+            action.name = 'heartbeat'
+            self.test_agent.telemetry_thread = None
+            self.test_agent.peripherals_thread = None
+            self.test_agent.run_single_cycle(action)
+            self.assertIsNone(self.test_agent.telemetry_thread)
+            self.assertIsNone(self.test_agent.peripherals_thread)
+
 
     def test_update_nuvlaedge_configuration(self):
         mock_current = {
@@ -203,6 +260,15 @@ class TestAgent(TestCase):
         self.test_agent._update_nuvlaedge_configuration()
         mock_update_periods.assert_called_once()
         mock_infra.commission_vpn.assert_called_once()
+
+        # old_nuvlaedge_data and on_nuvlaedge_update not set
+        self.test_agent.old_nuvlaedge_data = None
+        self.test_agent.on_nuvlaedge_update = None
+        mock_read_ne_doc = Mock()
+        mock_read_ne_doc.return_value = {}
+        self.test_agent._activate.read_ne_document_file = mock_read_ne_doc
+        self.test_agent._update_nuvlaedge_configuration()
+        mock_read_ne_doc.assert_called_once()
 
     @patch('nuvlaedge.agent.agent.Agent.fetch_nuvlaedge_resource')
     @patch('nuvlaedge.agent.agent.Agent._update_nuvlaedge_configuration')

--- a/tests/agent/test_nuvlaedge_common.py
+++ b/tests/agent/test_nuvlaedge_common.py
@@ -320,6 +320,27 @@ class NuvlaEdgeCommonTestCase(unittest.TestCase):
             self.assertIsNone(self.obj.set_local_operational_status(''),
                               'Setting the operational status should return nothing')
 
+    @mock.patch.object(Path, 'exists')
+    @mock.patch.object(Path, 'stat')
+    def test_get_vpn_ip(self, mock_stat, mock_exists):
+        # if vpn file does not exist or is empty, get None
+        mock_exists.return_value = False
+        self.assertIsNone(self.obj.get_vpn_ip(),
+                          'Returned VPN IP when VPN file does not exist')
+        mock_exists.return_value = True
+        mock_stat.return_value.st_size = 0
+        self.assertIsNone(self.obj.get_vpn_ip(),
+                          'Returned VPN IP when VPN file is empty')
+
+        # otherwise, read the file and return the IP
+        mock_stat.return_value.st_size = 1
+        # with mock.patch(self.agent_telemetry_open, mock.mock_open(read_data='1.1.1.1')):
+
+        with mock.patch.object(Path, 'open', mock.mock_open(read_data='1.1.1.1')):
+            self.assertEqual(self.obj.get_vpn_ip(), '1.1.1.1',
+                             'Failed to get VPN IP')
+
+
     def test_write_vpn_conf(self):
         with mock.patch(self.agent_nuvlaedge_common_open) as mock_open, \
              mock.patch(self.atomic_write):

--- a/tests/agent/test_telemetry.py
+++ b/tests/agent/test_telemetry.py
@@ -285,26 +285,6 @@ class TelemetryTestCase(unittest.TestCase):
         self.obj.status_on_nuvla = {'id': 'ID'}
         self.assertEqual('ID', self.obj.status_on_nuvla['id'])
 
-    @mock.patch.object(Path, 'exists')
-    @mock.patch.object(Path, 'stat')
-    def test_get_vpn_ip(self, mock_stat, mock_exists):
-        # if vpn file does not exist or is empty, get None
-        mock_exists.return_value = False
-        self.assertIsNone(self.obj.get_vpn_ip(),
-                          'Returned VPN IP when VPN file does not exist')
-        mock_exists.return_value = True
-        mock_stat.return_value.st_size = 0
-        self.assertIsNone(self.obj.get_vpn_ip(),
-                          'Returned VPN IP when VPN file is empty')
-
-        # otherwise, read the file and return the IP
-        mock_stat.return_value.st_size = 1
-        # with mock.patch(self.agent_telemetry_open, mock.mock_open(read_data='1.1.1.1')):
-
-        with mock.patch.object(Path, 'open', mock.mock_open(read_data='1.1.1.1')):
-            self.assertEqual(self.obj.get_vpn_ip(), '1.1.1.1',
-                             'Failed to get VPN IP')
-
     @mock.patch('time.sleep', return_value=None)
     @mock.patch('nuvlaedge.agent.monitor.Monitor.start')
     def test_update_monitors(self, mock_start, mock_sleep):

--- a/tests/agent/test_telemetry.py
+++ b/tests/agent/test_telemetry.py
@@ -97,11 +97,16 @@ class TelemetryTestCase(unittest.TestCase):
                          'Failed to initialized status structures')
         self.assertIsInstance(self.obj.mqtt_telemetry, mqtt.Client)
 
-    @mock.patch('nuvlaedge.agent.telemetry.active_monitors')
     @mock.patch('nuvlaedge.agent.telemetry.get_monitor')
-    def test_initialize_monitors(self, get_mock, act_mock):
+    def test_initialize_monitors(self, get_mock):
         get_mock.return_value = mock.Mock()
         self.obj.initialize_monitors()
+        monitor_count = len(self.obj.monitor_list)
+
+        self.obj.monitor_list = {}
+        self.obj.excluded_monitors = ['power', 'container_stats']
+        self.obj.initialize_monitors()
+        self.assertEqual(monitor_count-2, len(self.obj.monitor_list))
 
     @mock.patch('os.system')
     def test_send_mqtt(self, mock_system):
@@ -174,6 +179,24 @@ class TelemetryTestCase(unittest.TestCase):
         self.assertTrue(all(k in all_status for k in additional_fields),
                         'Failed to set additional status attributes for all_status, during get_status')
 
+        mock_send_mqtt.side_effect = AttributeError
+        _, all_status = self.obj.get_status()
+        self.assertNotIn('cpus', all_status)
+
+    def test_set_status_operational_status(self):
+        status = {}
+        mock_read_sys_issues = mock.Mock()
+        self.obj.coe_client.read_system_issues = mock_read_sys_issues
+
+        mock_read_sys_issues.return_value = ([], [])
+        self.obj.set_status_operational_status(status, {})
+
+        mock_read_sys_issues.return_value = (['system error'], [])
+        self.obj.installation_home = None
+        self.obj.set_status_operational_status(status, {})
+
+        self.assertEqual('DEGRADED', status['status'])
+
     def test_diff(self):
         # new values added, get new value and nothing to delete
         new = {'a': 1, 'b': 2}
@@ -210,6 +233,13 @@ class TelemetryTestCase(unittest.TestCase):
         self.assertEqual(self.obj.diff(old, new), expected,
                          'Failed to diff')
 
+        # one value is None
+        new = {'a': None, 'b': 2}
+        old = {'a': 1}
+        expected = ({'b': 2}, {'a'})
+        self.assertEqual(self.obj.diff(old, new), expected,
+                         'Failed to diff when a value is None')
+
     @mock.patch.object(Telemetry, 'diff')
     @mock.patch.object(Telemetry, 'get_status')
     def test_update_status(self, mock_get_status, mock_diff):
@@ -237,6 +267,22 @@ class TelemetryTestCase(unittest.TestCase):
         self.assertEqual(delete_attrs, set(),
                          'Saying there are attrs to delete when there are none')
 
+    def test_status_setitem(self):
+        self.obj.status['id'] = 'my-id'
+        self.assertEqual('my-id', self.obj.status['id'])
+
+    def test_status_setter(self):
+        self.obj.status = {'id': 'my/id'}
+        self.assertEqual('my/id', self.obj.status['id'])
+
+    def test_status_on_nuvla_setitem(self):
+        self.obj.status_on_nuvla['id'] = 'Id'
+        self.assertEqual('Id', self.obj.status_on_nuvla['id'])
+
+    def test_status_on_nuvla_setter(self):
+        self.obj.status_on_nuvla = {'id': 'ID'}
+        self.assertEqual('ID', self.obj.status_on_nuvla['id'])
+
     @mock.patch.object(Path, 'exists')
     @mock.patch.object(Path, 'stat')
     def test_get_vpn_ip(self, mock_stat, mock_exists):
@@ -256,3 +302,15 @@ class TelemetryTestCase(unittest.TestCase):
         with mock.patch.object(Path, 'open', mock.mock_open(read_data='1.1.1.1')):
             self.assertEqual(self.obj.get_vpn_ip(), '1.1.1.1',
                              'Failed to get VPN IP')
+
+    @mock.patch('nuvlaedge.agent.monitor.Monitor.run_update_data')
+    def test_update_monitors(self, mock_run_update_data):
+        self.obj.initialize_monitors()
+        status = {}
+        self.obj.update_monitors(status)
+
+        monitor = self.obj.monitor_list[list(self.obj.monitor_list)[0]]
+        monitor.updated = True
+        with mock.patch.object(monitor, 'populate_nb_report') as mock_populate_nb_report:
+            mock_populate_nb_report.side_effect = KeyError
+            self.obj.update_monitors(status)

--- a/tests/common/test_timed_actions.py
+++ b/tests/common/test_timed_actions.py
@@ -4,8 +4,11 @@ from mock import Mock, patch
 from nuvlaedge.common.timed_actions import ActionHandler, TimedAction
 
 
-def dummy_function():
-    return '0'
+def dummy_function(*args, **kwargs):
+    if not args and not kwargs:
+        return '0'
+    else:
+        return f'{args} {kwargs}'
 
 
 class TestTimedAction(TestCase):
@@ -29,6 +32,11 @@ class TestTimedAction(TestCase):
         self.action.remaining_time = 0
         self.assertEqual('0', self.action())
         self.assertEqual(self.action.remaining_time, self.action.period)
+
+        self.action.args = [1, 2, 3]
+        self.action.kwargs = {'a': 1, 'b': 2}
+        self.action.remaining_time = 0
+        self.assertEqual("(1, 2, 3) {'a': 1, 'b': 2}", self.action())
 
     def test_gt_lt(self):
         dummy_action = TimedAction(
@@ -106,3 +114,6 @@ class TestActionHandler(TestCase):
     def test_edit_period(self):
         self.handler.edit_period('TestCase', new_period=5)
         self.assertEqual(5, self.handler.actions[1].period)
+
+    def test_actions_summary(self):
+        self.assertTrue(len(self.handler.actions_summary().splitlines()) == 4)

--- a/tests/peripherals/test_peripheral.py
+++ b/tests/peripherals/test_peripheral.py
@@ -1,5 +1,5 @@
 import json
-from unittest import IsolatedAsyncioTestCase
+from unittest import TestCase
 
 import mock
 import pytest
@@ -8,7 +8,7 @@ from nuvlaedge.peripherals.peripheral import Peripheral
 from nuvlaedge.broker.file_broker import FileBroker
 
 
-class TestPeripheral(IsolatedAsyncioTestCase):
+class TestPeripheral(TestCase):
     def setUp(self) -> None:
         self.test_peripheral: Peripheral = Peripheral(name='test_peripheral')
         self.test_peripheral_async: Peripheral = Peripheral(name='test_peripheral_async', async_mode=True)
@@ -17,13 +17,13 @@ class TestPeripheral(IsolatedAsyncioTestCase):
         sample = {'d': 'd'}
         self.assertEqual(Peripheral.hash_discoveries({'d': 'd'}), hash(json.dumps(sample, sort_keys=True)))
 
-    async def test_run_single_iteration_async(self):
-        await self._test_run_single_iteration(async_mode=True)
+    def test_run_single_iteration_async(self):
+        self._test_run_single_iteration(async_mode=True)
 
-    async def test_run_single_iteration_sync(self):
-        await self._test_run_single_iteration()
+    def test_run_single_iteration_sync(self):
+        self._test_run_single_iteration()
 
-    async def _test_run_single_iteration(self, async_mode: bool = False):
+    def _test_run_single_iteration(self, async_mode: bool = False):
         if async_mode:
             mock_callable = mock.AsyncMock()
             test_peripheral = self.test_peripheral_async
@@ -32,11 +32,11 @@ class TestPeripheral(IsolatedAsyncioTestCase):
             test_peripheral = self.test_peripheral
         mock_callable.return_value = {}
         with mock.patch.object(FileBroker, 'publish') as mock_pub:
-            await test_peripheral.run_single_iteration(mock_callable)
+            test_peripheral.run_single_iteration(mock_callable)
             mock_pub.assert_not_called()
             mock_callable.assert_called_once()
 
             mock_callable.reset_mock()
             mock_callable.return_value = {'name': 'peripheral'}
-            await test_peripheral.run_single_iteration(mock_callable)
+            test_peripheral.run_single_iteration(mock_callable)
             mock_pub.assert_called_once()


### PR DESCRIPTION
fix(agent): issue where heartbeat might not work for 24 hours after a fresh install.
fix(agent): issue where telemetry monitors are run at the same time as threaded and not threaded.
fix(agent): issue where geolocation run limit of "max one per hour" is not applied (due to issue above).
feat(agent): refactor the way "nuvlabox" document is fetched from Nuvla and stored locally (both in memory and on disk).
minor(agent): increase the delay between two tries to activate nuvlaedge (from 3 to 5 seconds).
minor(agent): increase default thread period for monitors (from 10 to 60 seconds).