### PR TITLE
fix: harmonise datetime format across nuvlaedge. 

### DIFF
--- a/nuvlaedge/agent/workers/monitor/components/container_stats.py
+++ b/nuvlaedge/agent/workers/monitor/components/container_stats.py
@@ -14,7 +14,7 @@ from nuvlaedge.agent.workers.monitor.components import monitor
 from nuvlaedge.agent.orchestrator import COEClient
 from nuvlaedge.agent.common.util import execute_cmd
 from nuvlaedge.common.nuvlaedge_logging import get_nuvlaedge_logger
-
+from nuvlaedge.common.utils import format_datetime_for_nuvla
 
 logger: logging.Logger = get_nuvlaedge_logger(__name__)
 
@@ -32,7 +32,6 @@ class ContainerStatsMonitor(Monitor):
 
         self.nuvlaedge_id: str = telemetry.nuvlaedge_uuid
         self.swarm_node_cert_path: str = CTE.SWARM_NODE_CERTIFICATE
-        self.nuvla_timestamp_format: str = CTE.NUVLA_TIMESTAMP_FORMAT
 
         self.data.containers = {}
 
@@ -145,8 +144,7 @@ class ContainerStatsMonitor(Monitor):
         expiry_date_raw = cert_check.stdout.strip().split('=')[-1]
         raw_format = '%b %d %H:%M:%S %Y %Z'
 
-        return datetime.datetime.strptime(expiry_date_raw, raw_format).strftime(
-            self.nuvla_timestamp_format)
+        return format_datetime_for_nuvla(datetime.datetime.strptime(expiry_date_raw, raw_format))
 
     def update_data(self):
         self.refresh_container_info()

--- a/nuvlaedge/common/constants.py
+++ b/nuvlaedge/common/constants.py
@@ -4,8 +4,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class Constants:
     # FORMATS
-    DATETIME_FORMAT: str = "%m%d%Y%H%M%S"
-    NUVLA_TIMESTAMP_FORMAT: str = "%Y-%m-%dT%H:%M:%S.%fZ"
+    DATETIME_FORMAT: str = "%m%d%Y%H%M%S"  # Used for file names in the broker
 
     # Timeouts
     NETWORK_TIMEOUT: int = 10

--- a/nuvlaedge/common/utils.py
+++ b/nuvlaedge/common/utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 from contextlib import contextmanager
 import threading
+from datetime import datetime
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -35,3 +36,13 @@ def dump_dict_to_str(d: dict) -> str:
     if not isinstance(d, dict) or not d:
         return ""
     return json.dumps(d, indent=4)
+
+
+def format_datetime_for_nuvla(t: datetime) -> str:
+    """
+    Formats a datetime object to the Nuvla format
+    :param t: datetime object
+    :return: string formatted datetime
+    """
+    str_time = t.isoformat(timespec='milliseconds')
+    return str_time if str_time.endswith('Z') else str_time + 'Z'

--- a/nuvlaedge/peripherals/peripheral_manager_db.py
+++ b/nuvlaedge/peripherals/peripheral_manager_db.py
@@ -77,7 +77,8 @@ class PeripheralsDBManager:
         for i in set(self._local_db.keys()) - set(self._latest_update.keys()):
             if self._local_db.get(i).updated and self._local_db.get(i).updated != "":
                 try:
-                    self._latest_update[i] = datetime.strptime(self._local_db.get(i).updated, CTE.NUVLA_TIMESTAMP_FORMAT)
+                    self._latest_update[i] = datetime.fromisoformat(self._local_db.get(i).updated)
+
                 except Exception as e:
                     self.logger.warning(f'Error retrieving peripheral data for deletion: {e}')
 

--- a/tests/agent/monitor/components/test_container_stats.py
+++ b/tests/agent/monitor/components/test_container_stats.py
@@ -160,11 +160,10 @@ class TestContainerStatsMonitor(unittest.TestCase):
         # otherwise, get the expiration date
         mock_run.return_value.returncode = 0
         exp_date = 'Feb  6 05:41:00 2022 GMT'
-        test_monitor.nuvla_timestamp_format = "%Y-%m-%dT%H:%M:%SZ"
         mock_run.return_value.stdout = f'notAfter={exp_date}\n'
 
         self.assertEqual(test_monitor.get_swarm_certificate_expiration_date(),
-                         '2022-02-06T05:41:00Z',
+                         '2022-02-06T05:41:00.000Z',
                          'Unable to get Swarm node certificate expiration date')
 
     @patch('nuvlaedge.agent.workers.monitor.components.container_stats.ContainerStatsMonitor.'

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,9 +1,10 @@
 import threading
+from datetime import datetime
 
 from unittest import TestCase
 import mock
 
-from nuvlaedge.common.utils import timed_event, dump_dict_to_str
+from nuvlaedge.common.utils import timed_event, dump_dict_to_str, format_datetime_for_nuvla
 
 
 class TestUtils(TestCase):
@@ -18,6 +19,11 @@ class TestUtils(TestCase):
                 mock_cancel.assert_not_called()
 
             mock_cancel.assert_called_once()
+
+    def test_format_datetime_for_nuvla(self):
+        input_datetime = datetime(2022, 1, 1, 12, 0, 0, 123456)
+        expected_output = "2022-01-01T12:00:00.123Z"
+        self.assertEqual(format_datetime_for_nuvla(input_datetime), expected_output)
 
 
 def test_dump_dict_to_str():

--- a/tests/peripherals/test_peripheral_manager_db.py
+++ b/tests/peripherals/test_peripheral_manager_db.py
@@ -7,6 +7,7 @@ import mock
 
 import nuvlaedge.peripherals.peripheral_manager_db
 from nuvlaedge.common.constants import CTE
+from nuvlaedge.common.utils import format_datetime_for_nuvla
 from nuvlaedge.peripherals.peripheral_manager_db import PeripheralData, PeripheralsDBManager
 from nuvlaedge.models.nuvla_resources import NuvlaBoxPeripheralResource as PeripheralResource
 
@@ -56,7 +57,7 @@ class TestPeripheralsDBManager(TestCase):
         mock_collection.count = 1
         mock_data = mock.Mock
         t = datetime.now()
-        t_str = t.strftime(CTE.NUVLA_TIMESTAMP_FORMAT)
+        t_str = format_datetime_for_nuvla(t)
         mock_data.updated = t_str
         test_peripheral = {
             'id': mock_data
@@ -64,7 +65,7 @@ class TestPeripheralsDBManager(TestCase):
 
         mock_decode.return_value = test_peripheral
         self.test_db.synchronize()
-        self.assertEqual(self.test_db._latest_update, {'id': datetime.strptime(t_str, CTE.NUVLA_TIMESTAMP_FORMAT)})
+        self.assertEqual(self.test_db._latest_update, {'id': datetime.fromisoformat(t_str)})
         mock_storage.assert_called_once()
 
         # Test remove update from local registry


### PR DESCRIPTION
Use iso8601 + utc timezone, eg  strDate + 'Z'

```python
from datetime import datetime
t = datetime.now()
str_date = t.isoformat(timespec='milliseconds') + 'Z'

# result:  str_date = '2024-05-14T16:45:07.967Z'
```