### PR TITLE
fix: update collect_container_metrics() to support old_version parameter in K8s driver

### DIFF
--- a/nuvlaedge/agent/orchestrator/docker.py
+++ b/nuvlaedge/agent/orchestrator/docker.py
@@ -5,7 +5,7 @@ import os
 import socket
 import time
 from subprocess import run, PIPE, TimeoutExpired
-from typing import List, Optional
+from typing import List, Optional, Dict
 import requests
 import re
 import yaml
@@ -740,7 +740,7 @@ class DockerClient(COEClient):
                                f'{container.short_id} ({container.name}): {e}')
         return containers_stats
 
-    def collect_container_metrics(self, old_version=False):
+    def collect_container_metrics(self, old_version=False) -> List[Dict]:
         """
 
         Collects metrics for each container in the system.

--- a/nuvlaedge/agent/orchestrator/kubernetes.py
+++ b/nuvlaedge/agent/orchestrator/kubernetes.py
@@ -312,7 +312,7 @@ class KubernetesClient(COEClient):
                       namespace, exc_info=ex)
             raise ex
 
-    def collect_container_metrics(self) -> List[Dict]:
+    def collect_container_metrics(self, old_version: bool = False) -> List[Dict]:
         try:
             pods_here = self.client \
                 .list_pod_for_all_namespaces(


### PR DESCRIPTION
The actual implementation of the metrics publication with a new structure will be handled in:
[#3285 Add new metrics structure for publishing containers status in K8s driver](https://github.com/SixSq/tasklist/issues/3285)

Closes https://github.com/SixSq/tasklist/issues/3283