### PR TITLE
fix: fix issues with vpn handling

### DIFF
--- a/nuvlaedge/agent/common/util.py
+++ b/nuvlaedge/agent/common/util.py
@@ -149,6 +149,9 @@ up /opt/nuvlaedge/scripts/vpn-client/get_ip.sh
 auth-nocache
 auth-retry nointeract
 
+connect-retry 15
+connect-retry-max 4
+
 ping 60
 ping-restart 120
 compress lz4

--- a/nuvlaedge/agent/nuvla/client_wrapper.py
+++ b/nuvlaedge/agent/nuvla/client_wrapper.py
@@ -185,7 +185,7 @@ class NuvlaClientWrapper:
         return self._resources.get(_res_name)
 
     @property
-    def vpn_credential(self) -> CredentialResource | None:
+    def vpn_credential(self) -> AutoCredentialResource | None:
         if self.nuvlaedge.vpn_server_id is None:
             # This is a safety check. VPN server resource should only be requested if the NuvlaEdge has a VPN server
             logger.warning(f"VPN server not found in NuvlaEdge {self.nuvlaedge_uuid}. This point should not be reached")


### PR DESCRIPTION
- restart openvpn if it fail to connect too many time (which will force reload the config file and recreate vpn interface).
- do not save the new private key if the csr signing failed.
- reduce the load on Nuvla when checking for the creation of a new credential.
- force reload (bypass cache) credential from Nuvla after a new credential has been generated.